### PR TITLE
Improve Dockerfile for local builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,13 @@
-FROM alpine:3.9
-LABEL MAINTAINER furkan.sayim@yandex.com
-LABEL name ExtAnalysis
-LABEL src "https://github.com/Tuhinshubhra/ExtAnalysis"
-LABEL creator Tuhinshubhra
-LABEL desc "Browser Extension Analysis Framework"
+FROM python:3.11-slim AS builder
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --user --no-warn-script-location --no-cache-dir -r requirements.txt
 
-RUN apk add --no-cache python3 && \
-    python3 -m ensurepip && \
-    rm -r /usr/lib/python*/ensurepip && \
-    pip3 install --upgrade pip setuptools && \
-    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
-    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
-    rm -r /root/.cache
-
-RUN apk add git
-RUN git clone https://github.com/Tuhinshubhra/ExtAnalysis.git /tmp/extanalysis
-
-WORKDIR /tmp/extanalysis
-RUN pip3 install -r requirements.txt
+FROM python:3.11-slim
+WORKDIR /app
+COPY --from=builder /root/.local /root/.local
+ENV PATH=/root/.local/bin:$PATH
+COPY . .
 
 EXPOSE 13337
-
 ENTRYPOINT ["python3", "extanalysis.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ LABEL name="ExtAnalysis"
 LABEL creator="Tuhinshubhra"
 LABEL desc="Browser Extension Analysis Framework"
 WORKDIR /app
-COPY --from=builder /root/.local /root/.local
-ENV PATH=/root/.local/bin:$PATH
+COPY --from=builder /root/.local/lib /root/.local/lib
+ENV PYTHONPATH=/root/.local/lib/python3.11/site-packages:$PYTHONPATH
 COPY . .
 
 EXPOSE 13337

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM python:3.11-slim AS builder
 WORKDIR /app
 COPY requirements.txt ./
-RUN pip install --user --no-warn-script-location --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 FROM python:3.11-slim
 LABEL name="ExtAnalysis"
 LABEL creator="Tuhinshubhra"
 LABEL desc="Browser Extension Analysis Framework"
 WORKDIR /app
-COPY --from=builder /root/.local/lib /root/.local/lib
-ENV PYTHONPATH=/root/.local/lib/python3.11/site-packages:$PYTHONPATH
+COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
 COPY . .
 
 EXPOSE 13337

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ COPY requirements.txt ./
 RUN pip install --user --no-warn-script-location --no-cache-dir -r requirements.txt
 
 FROM python:3.11-slim
+LABEL name="ExtAnalysis"
+LABEL creator="Tuhinshubhra"
+LABEL desc="Browser Extension Analysis Framework"
 WORKDIR /app
 COPY --from=builder /root/.local /root/.local
 ENV PATH=/root/.local/bin:$PATH


### PR DESCRIPTION
# 🐳 Modernize Docker Setup: Multi-stage Build with Python 3.11

## Summary
Modernizes ExtAnalysis Docker setup by replacing Alpine-based approach with a multi-stage build using Python 3.11-slim for better performance and maintainability.

## Key Changes
- **Multi-stage build**: Dependencies built in separate stage for better caching
- **Python 3.11**: Upgraded from Alpine + manual Python to official Python 3.11-slim
- **Local development**: Uses `COPY . .` instead of git clone for faster iteration
- **Clean packages**: System-wide pip install following Docker best practices
- **Removed obsolete**: Dropped misleading `LABEL src` reference

## Before vs After
| Old | New |
|-----|-----|
| Alpine 3.9 + git clone | Python 3.11-slim + local copy |
| Single-stage build | Multi-stage build |
| Manual Python setup | Official Python image |

## Testing ✅
- Direct Docker: `docker run --rm -it -p 13337:13337 extanalysis -h 0.0.0.0`
- Docker Compose: `docker compose up --build`
- Web interface: HTTP 200 on localhost:13337

## Benefits
- 🚀 Faster builds (better layer caching)
- 🔄 Immediate testing of local changes
- 📏 Modern Docker best practices
- 🐍 Latest Python 3.11 with security updates

**No breaking changes** - all existing commands work as before.